### PR TITLE
bugfix: Fix directory permissions check

### DIFF
--- a/pkg/cis/controlplane/configuration_files.go
+++ b/pkg/cis/controlplane/configuration_files.go
@@ -175,7 +175,8 @@ func ConfigurationFiles(missingProcessFunc framework.MissingProcessHandlerFunc) 
 			})
 
 			It("[1.4.11] Ensure that the etcd data directory permissions are set to 700 or more restrictive [Scored]", func() {
-				Expect(etcdDataDir).To(HavePermissionsNumerically("<=", os.FileMode(0700)))
+				expectedPerm := os.FileMode(0700) | os.ModeDir
+				Expect(etcdDataDir).To(HavePermissionsNumerically("<=", expectedPerm))
 			})
 
 			It("[1.4.12] Ensure that the etcd data directory ownership is set to etcd:etcd [Scored]", func() {


### PR DESCRIPTION
We need to set the os.FileMode directory bit to properly compare directory permissions. Or else it fails with the following error when in fact the `data-dir` directory has the right permissions.
```
[1] Control plane [1.4] Configuration Files   [It] [1.4.11] Ensure that the etcd data directory permissions are set to 700 or more restrictive [Scored] 
/Users/simaoreis/Source/mesosphere/kubernetes-security-benchmark/pkg/cis/controlplane/configuration_files.go:177

  Expected
      <string>: 20000000700
  file permissions of /mnt/mesos/sandbox/data-dir to be <=
      <string>: 0700
```